### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -8,6 +8,9 @@
 
 name: Java CI with Maven
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/AntiEmuForce/bobbysoft-organizer/security/code-scanning/1](https://github.com/AntiEmuForce/bobbysoft-organizer/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function. Since the workflow only builds a Java project with Maven and does not perform any write operations, we will set `contents: read` as the permission. This ensures that the workflow has only the necessary read access to the repository contents.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
